### PR TITLE
fix(ci): unblock renovate via lint fixes and shared preset migration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           args: --timeout=5m
 
       - name: markdownlint

--- a/internal/dnsmetrics/metrics.go
+++ b/internal/dnsmetrics/metrics.go
@@ -4,6 +4,11 @@ import "github.com/prometheus/client_golang/prometheus"
 
 const namespace = "external_dns_unifi"
 
+// Metric label keys.
+const (
+	labelOperation = "operation"
+)
+
 //nolint:gochecknoglobals // Prometheus metrics must be global
 var (
 	// DNSOperationsTotal tracks the total number of DNS operations (create/update/delete).
@@ -13,7 +18,7 @@ var (
 			Name:      "dns_operations_total",
 			Help:      "Total number of DNS operations",
 		},
-		[]string{"operation", "status"}, // operation: create/update/delete, status: success/error
+		[]string{labelOperation, "status"}, // operation: create/update/delete, status: success/error
 	)
 
 	// DNSOperationDuration tracks the duration of DNS operations.
@@ -24,7 +29,7 @@ var (
 			Help:      "Duration of DNS operations in seconds",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"operation"}, // operation: create/update/delete
+		[]string{labelOperation}, // operation: create/update/delete
 	)
 
 	// DNSRecordsManaged tracks the number of DNS records currently managed by type.

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -26,7 +26,6 @@ func Logging(next http.Handler) http.Handler {
 
 		defer func() {
 			if err := recover(); err != nil {
-				//nolint:gosec // G706: slog uses structured fields, not string interpolation — no log injection risk
 				slog.Error("panic recovered",
 					"error", fmt.Sprintf("%v", err),
 					"stack", string(debug.Stack()),

--- a/internal/observability/prometheus_recorder.go
+++ b/internal/observability/prometheus_recorder.go
@@ -8,6 +8,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Metric label keys.
+const (
+	labelMethod    = "method"
+	labelPath      = "path"
+	labelEndpoint  = "endpoint"
+	labelOperation = "operation"
+)
+
 // PrometheusRecorder implements observability.MetricsRecorder using Prometheus.
 type PrometheusRecorder struct {
 	httpRequests         *prometheus.CounterVec
@@ -29,7 +37,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Name:      "unifi_api_requests_total",
 				Help:      "Total number of UniFi API HTTP requests",
 			},
-			[]string{"method", "path", "status_code"},
+			[]string{labelMethod, labelPath, "status_code"},
 		),
 		httpDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -38,7 +46,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Help:      "Duration of UniFi API HTTP requests in seconds",
 				Buckets:   prometheus.DefBuckets,
 			},
-			[]string{"method", "path"},
+			[]string{labelMethod, labelPath},
 		),
 		retries: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -46,7 +54,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Name:      "unifi_api_retries_total",
 				Help:      "Total number of UniFi API retry attempts",
 			},
-			[]string{"endpoint"},
+			[]string{labelEndpoint},
 		),
 		rateLimits: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -54,7 +62,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Name:      "unifi_api_rate_limits_total",
 				Help:      "Total number of UniFi API rate limit events",
 			},
-			[]string{"endpoint"},
+			[]string{labelEndpoint},
 		),
 		errors: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -62,7 +70,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Name:      "unifi_api_errors_total",
 				Help:      "Total number of UniFi API errors",
 			},
-			[]string{"operation", "error_type"},
+			[]string{labelOperation, "error_type"},
 		),
 		contextCancellations: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -70,7 +78,7 @@ func NewPrometheusRecorder(registry *prometheus.Registry, namespace string) *Pro
 				Name:      "unifi_api_context_cancellations_total",
 				Help:      "Total number of UniFi API context cancellations",
 			},
-			[]string{"operation"},
+			[]string{labelOperation},
 		),
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -15,6 +15,14 @@ import (
 	unifi "github.com/lexfrei/go-unifi/api/network"
 )
 
+// Shared test fixtures for DNS record names and target addresses.
+const (
+	testNewDNSName    = "new.example.com"
+	testNewTarget     = "192.168.1.10"
+	testUpdateDNSName = "update.example.com"
+	testUpdateTarget  = "192.168.1.31"
+)
+
 // MockNetworkClient is a mock implementation of unifi.NetworkAPIClient for testing.
 type MockNetworkClient struct {
 	mock.Mock
@@ -261,14 +269,14 @@ func TestApplyChanges_Create(t *testing.T) {
 	ttl := 300
 	createdRecord := &unifi.DNSRecord{
 		UnderscoreId: "new-record-id",
-		Key:          "new.example.com",
-		Value:        "192.168.1.10",
+		Key:          testNewDNSName,
+		Value:        testNewTarget,
 		RecordType:   unifi.DNSRecordRecordTypeA,
 		Ttl:          &ttl,
 	}
 
 	mockClient.On("CreateDNSRecord", mock.Anything, unifi.Site("default"), mock.MatchedBy(func(input *unifi.DNSRecordInput) bool {
-		return input.Key == "new.example.com" && input.Value == "192.168.1.10"
+		return input.Key == testNewDNSName && input.Value == testNewTarget
 	})).Return(createdRecord, nil)
 
 	provider := New(mockClient, "default", domainFilter)
@@ -276,9 +284,9 @@ func TestApplyChanges_Create(t *testing.T) {
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
-				DNSName:    "new.example.com",
+				DNSName:    testNewDNSName,
 				RecordType: endpoint.RecordTypeA,
-				Targets:    []string{"192.168.1.10"},
+				Targets:    []string{testNewTarget},
 			},
 		},
 	}
@@ -332,14 +340,14 @@ func TestApplyChanges_Update(t *testing.T) {
 	domainFilter := endpoint.DomainFilter{}
 
 	existingRecords := []unifi.DNSRecord{
-		createMockDNSRecord("update.example.com", "192.168.1.30", unifi.DNSRecordRecordTypeA),
+		createMockDNSRecord(testUpdateDNSName, "192.168.1.30", unifi.DNSRecordRecordTypeA),
 	}
 
 	ttl := 300
 	newRecord := &unifi.DNSRecord{
 		UnderscoreId: "updated-record-id",
-		Key:          "update.example.com",
-		Value:        "192.168.1.31",
+		Key:          testUpdateDNSName,
+		Value:        testUpdateTarget,
 		RecordType:   unifi.DNSRecordRecordTypeA,
 		Ttl:          &ttl,
 	}
@@ -351,7 +359,7 @@ func TestApplyChanges_Update(t *testing.T) {
 		Return(nil)
 
 	mockClient.On("CreateDNSRecord", mock.Anything, unifi.Site("default"), mock.MatchedBy(func(input *unifi.DNSRecordInput) bool {
-		return input.Key == "update.example.com" && input.Value == "192.168.1.31"
+		return input.Key == testUpdateDNSName && input.Value == testUpdateTarget
 	})).Return(newRecord, nil)
 
 	provider := New(mockClient, "default", domainFilter)
@@ -359,16 +367,16 @@ func TestApplyChanges_Update(t *testing.T) {
 	changes := &plan.Changes{
 		UpdateOld: []*endpoint.Endpoint{
 			{
-				DNSName:    "update.example.com",
+				DNSName:    testUpdateDNSName,
 				RecordType: endpoint.RecordTypeA,
 				Targets:    []string{"192.168.1.30"},
 			},
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			{
-				DNSName:    "update.example.com",
+				DNSName:    testUpdateDNSName,
 				RecordType: endpoint.RecordTypeA,
-				Targets:    []string{"192.168.1.31"},
+				Targets:    []string{testUpdateTarget},
 			},
 		},
 	}

--- a/internal/webhookserver/server.go
+++ b/internal/webhookserver/server.go
@@ -16,6 +16,12 @@ const (
 	// maxRequestBodySize limits the maximum size of HTTP request body to prevent memory exhaustion.
 	// 5MB allows handling ~25,000 DNS records in a single request (observed: 20k records in production).
 	maxRequestBodySize = 5 << 20 // 5MB
+
+	// errorKey is the JSON field used to convey error messages in HTTP responses.
+	errorKey = "error"
+
+	// msgInvalidRequestBody is the error message returned for malformed request bodies.
+	msgInvalidRequestBody = "invalid request body"
 )
 
 // Server implements the webhook.ServerInterface for external-dns webhook protocol.
@@ -57,10 +63,10 @@ func (s *Server) GetRecords(w http.ResponseWriter, r *http.Request, _ webhook.Ge
 	// Fetch records from provider
 	endpoints, err := s.provider.Records(r.Context())
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to get records", "error", err)
+		slog.ErrorContext(r.Context(), "failed to get records", errorKey, err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{errorKey: err.Error()})
 
 		return
 	}
@@ -93,15 +99,15 @@ func (s *Server) SetRecords(w http.ResponseWriter, r *http.Request, _ webhook.Se
 			slog.WarnContext(r.Context(), "request body too large", "limit_bytes", maxRequestBodySize)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "request body too large"})
+			_ = json.NewEncoder(w).Encode(map[string]string{errorKey: "request body too large"})
 
 			return
 		}
 
-		slog.ErrorContext(r.Context(), "failed to decode changes", "error", err)
+		slog.ErrorContext(r.Context(), "failed to decode changes", errorKey, err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+		_ = json.NewEncoder(w).Encode(map[string]string{errorKey: msgInvalidRequestBody})
 
 		return
 	}
@@ -112,10 +118,10 @@ func (s *Server) SetRecords(w http.ResponseWriter, r *http.Request, _ webhook.Se
 	// Apply changes using provider
 	err = s.provider.ApplyChanges(r.Context(), planChanges)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to apply changes", "error", err)
+		slog.ErrorContext(r.Context(), "failed to apply changes", errorKey, err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{errorKey: err.Error()})
 
 		return
 	}
@@ -132,10 +138,10 @@ func (s *Server) AdjustRecords(w http.ResponseWriter, r *http.Request, _ webhook
 
 	err := json.NewDecoder(r.Body).Decode(&endpoints)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to bind endpoints", "error", err)
+		slog.ErrorContext(r.Context(), "failed to bind endpoints", errorKey, err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+		_ = json.NewEncoder(w).Encode(map[string]string{errorKey: msgInvalidRequestBody})
 
 		return
 	}
@@ -149,10 +155,10 @@ func (s *Server) AdjustRecords(w http.ResponseWriter, r *http.Request, _ webhook
 	// Provider's AdjustEndpoints (currently just returns the same endpoints)
 	adjusted, err := s.provider.AdjustEndpoints(externalEndpoints)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "failed to adjust endpoints", "error", err)
+		slog.ErrorContext(r.Context(), "failed to adjust endpoints", errorKey, err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{errorKey: err.Error()})
 
 		return
 	}
@@ -305,7 +311,7 @@ func (s *Server) decodeChanges(r *http.Request) (*webhook.Changes, error) {
 	err := decoder.Decode(&changes)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "failed to decode changes",
-			"error", err,
+			errorKey, err,
 			"content_type", r.Header.Get("Content-Type"))
 
 		return nil, errors.Wrap(err, "failed to decode changes")

--- a/internal/webhookserver/server_bench_test.go
+++ b/internal/webhookserver/server_bench_test.go
@@ -10,6 +10,13 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
+// Benchmark sub-test names by endpoint count.
+const (
+	test10Endpoints  = "10_endpoints"
+	test50Endpoints  = "50_endpoints"
+	test100Endpoints = "100_endpoints"
+)
+
 // generateWebhookEndpoints creates a slice of webhook endpoints for benchmarking.
 func generateWebhookEndpoints(count int) webhook.Endpoints {
 	endpoints := make(webhook.Endpoints, count)
@@ -56,9 +63,9 @@ func BenchmarkConvertToWebhookEndpoint(b *testing.B) {
 		name  string
 		count int
 	}{
-		{"10_endpoints", 10},
-		{"50_endpoints", 50},
-		{"100_endpoints", 100},
+		{test10Endpoints, 10},
+		{test50Endpoints, 50},
+		{test100Endpoints, 100},
 	}
 
 	for _, bm := range benchmarks {
@@ -82,9 +89,9 @@ func BenchmarkConvertFromWebhookEndpoint(b *testing.B) {
 		name  string
 		count int
 	}{
-		{"10_endpoints", 10},
-		{"50_endpoints", 50},
-		{"100_endpoints", 100},
+		{test10Endpoints, 10},
+		{test50Endpoints, 50},
+		{test100Endpoints, 100},
 	}
 
 	for _, bm := range benchmarks {
@@ -125,9 +132,9 @@ func BenchmarkJSONEncoder(b *testing.B) {
 		name  string
 		count int
 	}{
-		{"10_endpoints", 10},
-		{"50_endpoints", 50},
-		{"100_endpoints", 100},
+		{test10Endpoints, 10},
+		{test50Endpoints, 50},
+		{test100Endpoints, 100},
 	}
 
 	for _, bench := range benchmarks {
@@ -151,9 +158,9 @@ func BenchmarkJSONDecoder(b *testing.B) {
 		name  string
 		count int
 	}{
-		{"10_endpoints", 10},
-		{"50_endpoints", 50},
-		{"100_endpoints", 100},
+		{test10Endpoints, 10},
+		{test50Endpoints, 50},
+		{test100Endpoints, 100},
 	}
 
 	for _, bench := range benchmarks {

--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "packageRules": [
-    {
-      "description": "Automerge all updates including major",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "description": "Bump Go version in go.mod",
-      "matchDatasources": ["golang-version"],
-      "rangeStrategy": "bump"
-    }
-  ]
+  "extends": ["github>lexfrei/renovate-config"]
 }


### PR DESCRIPTION
# Pull Request

## Summary

Unblocks Renovate on this repository. The required Lint check was red on master because `golangci-lint-action` ran with `version: latest`, which surfaced pre-existing goconst findings and one stale `//nolint` directive. With Lint failing, none of the open Renovate PRs could merge. This PR fixes the lint findings, pins the linter to a Renovate-tracked version, and migrates the Renovate config to the shared `lexfrei/renovate-config` preset.

## Changes

- Hoist repeated string literals to named constants to clear all goconst findings (metric label keys, JSON response fields, error messages, benchmark sub-test names).
- Remove a stale `gosec` `//nolint` directive that the linter reports as unused.
- Pin `golangci-lint` to an explicit, Renovate-annotated version instead of `latest`, so CI lint results are reproducible and version bumps go through a reviewable PR.
- Migrate `renovate.json` to extend the shared `github>lexfrei/renovate-config` preset, dropping inline keys the preset already provides.

No runtime logic changed; the Go edits are constant extraction only.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run` — 0 issues with `--max-issues-per-linter=0 --max-same-issues=0`)
- [ ] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown changed
- [ ] Manual testing completed (if applicable) — N/A

## Documentation

- [ ] README updated (if needed) — N/A
- [ ] Code comments added for complex logic — N/A (mechanical constant extraction)
- [ ] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [ ] Related issues referenced (if any) — N/A

## Additional Notes

The shared preset automerges minor/patch/pin/digest updates plus all GitHub Actions updates, and lets major dependency updates open a PR for review. This differs from the previous inline config, which automerged everything including major non-action updates.
