### PR TITLE
fix(renovate): hold kin-openapi at 0.138.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>lexfrei/renovate-config"]
+  "extends": ["github>lexfrei/renovate-config"],
+  "packageRules": [
+    {
+      "description": "Hold kin-openapi at 0.138.x. Every later release requires oasdiff/yaml v0.1.1, which brings in go-openapi/swag/loading, whose test imports github.com/go-openapi/testify/v2/assert/yaml - a package that module does not contain. go mod tidy fails on the bump, so Renovate cannot regenerate go.sum and the PR arrives as a go.mod-only change that CI rejects for a missing go.sum entry. Downgrading oasdiff/yaml is not possible, kin-openapi requires that exact version. Remove this rule once go mod tidy succeeds with a newer kin-openapi.",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/getkin/kin-openapi"],
+      "allowedVersions": "<0.139.0"
+    }
+  ]
 }


### PR DESCRIPTION
kin-openapi 0.144.0 and 0.145.0 both break `go mod tidy` in this repo, and that breaks every other Go update.

The chain: any release above 0.138 requires `oasdiff/yaml` v0.1.1, which brings in `go-openapi/swag/loading`, whose test imports `github.com/go-openapi/testify/v2/assert/yaml`. That module exists at v2.6.0 and does not contain the package:

```text
go-openapi/testify/v2/assert/yaml: module github.com/go-openapi/testify/v2@latest found (v2.6.0), but does not contain package
```

So tidy exits non-zero, Renovate cannot regenerate go.sum, and the PR lands as a go.mod-only change that CI rejects with `missing go.sum entry`. Which is the same failure that had every dependency PR here red until the genproto fix.

Pinning `oasdiff/yaml` back does not work, kin-openapi requires that exact version. Nothing in this repo can fix it, so the dependency is held until the package reappears upstream or swag stops importing it.

The cost is the open advisory on kin-openapi staying open. Build, tests and lint all pass with the bump applied, so if the advisory matters more than tidy, the alternative is to merge it and accept that Renovate stops maintaining go.sum here.